### PR TITLE
Add link to privacy policy in footer.

### DIFF
--- a/theme/_includes/footer.html
+++ b/theme/_includes/footer.html
@@ -14,6 +14,8 @@
             <img src="/img/github-mark-32px.png" alt="RAC GitHub link">
           </a>
         </li>
+        <li>
+          <a href="https://rockarch.org/about-us/privacy-policy/">RAC Privacy Policy</a>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Fixes #111 . Adds a link to the privacy policy in bottom right of the footer.

I put this one in the bottom right, but it could easily go to the left. I'd probably just have to make a new row.