### PR TITLE
Use description in docs config for meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ should be either `true` or `false` (booleans, not strings).
 `title` is the official title of the documentation, which will be displayed on
 the home page of the site.
 
-`description` is a short statement of what the documentation is, limited to 160 characters. This text will become the description meta tag for the site, which is displayed in search-engine results.
+`description` is a statement of what the documentation is. This text will become the description meta tag for the site, which is displayed in search-engine results, so keep it short and snappy.
 
 `pages` is a list of lists of the pages included in this site. The first value
 in each list is the name, and the second is the filename of the page (without the

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ documentation repository. These files should be valid [YAML](http://yaml.org).
     tags:
       - "policy"
     title: "Collection Policy"
+    description: "The main collecting areas of the Rockefeller Archive Center."
     pages:
       - ["Rockefeller Archive Center Collection Policy", "index"]
 
@@ -108,6 +109,8 @@ should be either `true` or `false` (booleans, not strings).
 
 `title` is the official title of the documentation, which will be displayed on
 the home page of the site.
+
+`description` is a short statement of what the documentation is, limited to 160 characters. This text will become the description meta tag for the site, which is displayed in search-engine results.
 
 `pages` is a list of lists of the pages included in this site. The first value
 in each list is the name, and the second is the filename of the page (without the

--- a/theme/_includes/head.html
+++ b/theme/_includes/head.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
-  <meta name="description" content="{% if page.description %}{{ page.description | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
 
   <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">

--- a/theme/_includes/head.html
+++ b/theme/_includes/head.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+  <meta name="description" content="{% if page.description %}{{ page.description | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
   <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">


### PR DESCRIPTION
Resolves #47 

We removed the requirement of the `description` in the doc config files in PR #115 . However, after thinking a bit about SEO, using the descriptions as the meta page descriptions in the `<head>` might be a nice addition to search engine results, since they would appear as more specific page descriptions instead of the generic site description.

If we incorporate this change, we should do a quick review of existing docs descriptions and add them if they do not exist.