### PR TITLE
Correctly pull meta description from config

### DIFF
--- a/theme/_includes/head.html
+++ b/theme/_includes/head.html
@@ -4,12 +4,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
-  {% for file in site.data %}
-    {% if page.dir contains file[0] %}
-    {% assign doc = file[1] %}
-      <meta name="description" content="{% if doc.description %}{{ doc.description }}{% else %}{{ site.description }}{% endif %}">
-    {% endif %}
-  {% endfor %}
+  {%- for file in site.data -%}
+    {%- if page.dir contains file[0] -%}
+    {%- assign doc = file[1] -%}
+      <meta name="description" content="{%- if doc.description -%}{{ doc.description }}{%- else -%}{{ site.description }}{%- endif -%}">
+    {%- endif -%}
+  {%- endfor -%}
   <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">

--- a/theme/_includes/head.html
+++ b/theme/_includes/head.html
@@ -4,8 +4,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
-  <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
-
+  {% for file in site.data %}
+    {% if page.dir contains file[0] %}
+    {% assign doc = file[1] %}
+      <meta name="description" content="{% if doc.description %}{{ doc.description }}{% else %}{{ site.description }}{% endif %}">
+    {% endif %}
+  {% endfor %}
   <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">


### PR DESCRIPTION
Creates the meta description value in the `<head>`by pulling the `description` data from the config file of a set of docs instead of pulling from the YAML front matter of each doc's markdown file.

I tested this locally and it is working as intended, including for docs with multiple pages.