### PR TITLE
add padding and darken inline background

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = repositories/docs-guide
 	url = https://github.com/RockefellerArchiveCenter/docs-guide.git
 	branch = base
+[submodule "repositories/argo"]
+	path = repositories/argo
+	url = https://github.com/RockefellerArchiveCenter/argo.git
+	branch = docs-development

--- a/theme/_sass/syntax_highlight.scss
+++ b/theme/_sass/syntax_highlight.scss
@@ -2,7 +2,7 @@
 Source: mpchadwick at https://github.com/mpchadwick/pygments-high-contrast-stylesheets */
 
 .highlight .hll { background-color: #404040; }
-.highlight { background: #202020; color: #d0d0d0; }
+.highlight { background: #202020; color: #d0d0d0; padding: 5px; }
 .highlight .c { color: #999999; font-style: italic; }
 .highlight .err { color: #a61717; background-color: #e3d2d2; }
 .highlight .esc { color: #d0d0d0; }
@@ -83,5 +83,6 @@ Source: mpchadwick at https://github.com/mpchadwick/pygments-high-contrast-style
 /* Inline code styles (colors from RAC styles library) */
 .highlighter-rouge {
     color: #9F3C0F;
-    background-color: #F6F6F4;
+    background-color: #E3E1DD;
+    padding: 2px;
 }


### PR DESCRIPTION
Further improvements to #129 

- Adds some padding and darkens the inline code background color to #e3e1dd (RAC's `wan-white-grey` color).