### PR TITLE
Add accessibility statement link

### DIFF
--- a/theme/_includes/footer.html
+++ b/theme/_includes/footer.html
@@ -2,7 +2,7 @@
   <hr/>
   <div class="row">
     <div class="col-md-12">
-      <p class="ml-3 float-left">Powered by <a href="//jekyllrb.com">Jekyll</a></p>
+      <p class="ml-3 float-left"><a href="https://rockarch.org/about-us/accessibility/">Accessibility Statement</a></p>
       <p class="ml-3 float-left"><a href="https://rockarch.org/about-us/privacy-policy/">RAC Privacy Policy</a></p>
       <ul class="list-inline float-right mr-3">
         <li class="list-inline-item">


### PR DESCRIPTION
Replaces "powered by Jekyll" in footer with a link to the RAC accessibility statement