### PR TITLE
Remove Social Media Policy Docs

### DIFF
--- a/repositories.yml
+++ b/repositories.yml
@@ -9,7 +9,6 @@ private:
   - RockefellerArchiveCenter/reading-room-manual
   - RockefellerArchiveCenter/reappraisal-policy
   - RockefellerArchiveCenter/rm-policy
-  - RockefellerArchiveCenter/social-media-policy
   - RockefellerArchiveCenter/textile-policy
   - RockefellerArchiveCenter/valuable-vulnerable-policy
   - RockefellerArchiveCenter/library-policy
@@ -41,7 +40,6 @@ public:
   - RockefellerArchiveCenter/reading-room-manual
   - RockefellerArchiveCenter/reappraisal-policy
   - RockefellerArchiveCenter/rm-policy
-  - RockefellerArchiveCenter/social-media-policy
   - RockefellerArchiveCenter/textile-policy
   - RockefellerArchiveCenter/valuable-vulnerable-policy
   - RockefellerArchiveCenter/library-policy


### PR DESCRIPTION
The [R&E Content Strategy Docs](https://github.com/RockefellerArchiveCenter/r-e-content-strategy) are replacing the social media policy, so we're removing it from the Docs Site.