### PR TITLE
Adjust side-nav logic to account for page titles containing the same word

### DIFF
--- a/theme/_includes/side-nav.html
+++ b/theme/_includes/side-nav.html
@@ -6,8 +6,8 @@
         {% if page.dir contains file[0] %}
         {% assign pages = file[1].pages %}
           {% for p in pages %}
-            <a class="list-group-item list-group-item-action nounderline{% if page.name contains p[1] %} active{% endif %}" href="{{site.url}}/{{file[0]}}/{% if p[1] != 'index' %}{{p[1]}}{% endif %}">{{p[0]}}</a>
-            {% if page.name contains p[1] %} <div id="current" class="list-group"></div>{% endif %}
+            <a class="list-group-item list-group-item-action nounderline{% if page.name == p[1] %} active{% endif %}" href="{{site.url}}/{{file[0]}}/{% if p[1] != 'index' %}{{p[1]}}{% endif %}">{{p[0]}}</a>
+            {% if page.name == p[1] %} <div id="current" class="list-group"></div>{% endif %}
           {% endfor %}
         {% endif %}
       {% endfor %}

--- a/theme/js/toc.js
+++ b/theme/js/toc.js
@@ -1,4 +1,4 @@
-$(document).ready(function(){
+(function($){
   $.fn.toc = function(options) {
     var defaults = {
       noBackToTopLinks: false,


### PR DESCRIPTION
Attempting to fix #209 . The table of contents in the docs repo that is having issues has two page titles that both contain the word "policies". I'm trying to adjust the liquid logic in `side-nav.html` to only assign `id="current"` and `class="list-group"` to the page with the exact title match, since right now both page titles with the word "policies" are getting those selectors assigned to them.