### PR TITLE
Updates scripts for local development

### DIFF
--- a/apache/httpd.conf
+++ b/apache/httpd.conf
@@ -4,9 +4,9 @@ ServerName localhost
 
 <VirtualHost *:4000>
 
-  DocumentRoot /tmp/build
+  DocumentRoot /tmp/build/public
 
-  <Directory /tmp/build>
+  <Directory /tmp/build/public>
     Require all granted
   </Directory>
 

--- a/apache/httpd.conf
+++ b/apache/httpd.conf
@@ -4,10 +4,8 @@ ServerName localhost
 
 <VirtualHost *:4000>
   DocumentRoot /tmp/build/public/
-  DirectoryIndex index.html
 
   <Directory /tmp/build/public/>
     Require all granted
-    Options +Indexes
   </Directory>
 </VirtualHost>

--- a/apache/httpd.conf
+++ b/apache/httpd.conf
@@ -3,11 +3,11 @@ Listen 4000
 ServerName localhost
 
 <VirtualHost *:4000>
+  DocumentRoot /tmp/build/public/
+  DirectoryIndex index.html
 
-  DocumentRoot /tmp/build/public
-
-  <Directory /tmp/build/public>
+  <Directory /tmp/build/public/>
     Require all granted
+    Options +Indexes
   </Directory>
-
 </VirtualHost>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,5 @@ services:
       - .:/home/docs/docs-build/
     ports:
       - 4000:4000
-      - 4001:4001
     environment:
       - TRAVIS_CI=${TRAVIS_CI:-false}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,25 +2,23 @@
 
 # This currently does not work because calling update.py without an event doesn't do anything.
 
-if [ -z "$TRAVIS_CI" ]
-then
-  echo "Performing initial build of site"
-  python ./update.py
 
-  echo "Starting Apache"
-  /usr/sbin/apachectl start
+echo "Performing initial build of site"
+python ./update.py
 
-  echo "
+echo "Starting Apache"
+/usr/sbin/apachectl start
+
+echo "
 Sites built successfully!
-  Public site available at http://localhost:4000
-  Private site available at http://localhost:4001
+Public site available at http://localhost:4000
+Private site available at http://localhost:4001
 "
 
-  inotifywait -e modify,move,create,delete -m theme/ -r |
-  while read filename; do
-    echo "Regenerating..."
-    python ./update.py
-done
-else
+inotifywait -e modify,move,create,delete -m theme/ -r |
+while read filename; do
+  echo "Regenerating..."
   python ./update.py
+done
+
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# This currently does not work because calling update.py without an event doesn't do anything.
-
 
 echo "Performing initial build of site"
 python ./update.py
@@ -10,9 +8,8 @@ echo "Starting Apache"
 /usr/sbin/apachectl start
 
 echo "
-Sites built successfully!
+Site built successfully!
 Public site available at http://localhost:4000
-Private site available at http://localhost:4001
 "
 
 inotifywait -e modify,move,create,delete -m theme/ -r |

--- a/update.py
+++ b/update.py
@@ -182,7 +182,7 @@ def main(event=None, context=None):
     else:
         if os.getenv("TRAVIS_CI", "false") != "true":
             # Execute update routine for local build
-            deploy=False
+            deploy = False
             audience = 'public'
             branch = 'base'
             UpdateRoutine().run(audience, branch, deploy)

--- a/update.py
+++ b/update.py
@@ -180,11 +180,12 @@ def main(event=None, context=None):
                 'body': str(e)
             }
     else:
-        """Execute update routine for local build"""
-        deploy=False
-        audience = 'public'
-        branch = 'base'
-        UpdateRoutine().run(audience, branch, deploy)
+        if os.getenv("TRAVIS_CI", "false") != "true":
+            # Execute update routine for local build
+            deploy=False
+            audience = 'public'
+            branch = 'base'
+            UpdateRoutine().run(audience, branch, deploy)
 
 if __name__ == '__main__':
     main()

--- a/update.py
+++ b/update.py
@@ -180,7 +180,7 @@ def main(event=None, context=None):
                 'body': str(e)
             }
     else:
-        """Executing update routine for local build"""
+        """Execute update routine for local build"""
         deploy=False
         audience = 'public'
         branch = 'base'

--- a/update.py
+++ b/update.py
@@ -56,15 +56,17 @@ class UpdateRoutine:
                 except KeyError:
                     raise Exception(f'No build destination for {audience} {branch} site')
 
-            with open('repositories.yml') as f:
-                repositories_config = yaml.safe_load(f)
-            site = Site(audience)
-            site.update_theme()
-            site.stage(repositories_config[audience], branch, audience)
-            site.build()
-            if deploy:
-                site.upload(audience, branch)
-            return f'Update process for {audience} {branch} site completed at {datetime.now()}'
+        with open('repositories.yml') as f:
+            repositories_config = yaml.safe_load(f)
+        site = Site(audience)
+        site.update_theme()
+        site.stage(repositories_config[audience], branch, audience)
+        site.build()
+        if deploy:
+            site.upload(audience, branch)
+        else:
+            logging.info(f'Skipping upload to S3 for {audience} {branch} site.')
+        return f'Update process for {audience} {branch} site completed at {datetime.now()}'
 
 
 class Site:
@@ -177,7 +179,12 @@ def main(event=None, context=None):
                 'statusCode': 500,
                 'body': str(e)
             }
-
+    else:
+        """Executing update routine for local build"""
+        deploy=False
+        audience = 'public'
+        branch = 'base'
+        UpdateRoutine().run(audience, branch, deploy)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fixes #210 

Enables local development in docker by adjusting `update.py` to run the update routine when there is no event (excluding in a Travis CI environment).

Also removes references to building the private site locally in Apache, which needs a GH Token and I'm not sure is worth make work here.