### PR TITLE
Add GitHub Actions Workflow to Publish to SNS

### DIFF
--- a/.github/workflows/publish_sns.yml
+++ b/.github/workflows/publish_sns.yml
@@ -1,0 +1,23 @@
+name: Publish to SNS
+on:
+  push:
+    branches:
+      - base
+      - development
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Publish SNS Notification
+      uses: nothingalike/sns-publish-topic@v1.6
+      with:
+        MESSAGE: ${{ toJSON(github) }}
+        TOPIC_ARN: "arn:aws:sns:${{ secrets.AWS_DOCS_REGION }}:${{ secrets.AWS_DOCS_ACCOUNT_ID }}:${{ secrets.AWS_DOCS_SNS_TOPIC }}"
+      env:
+        AWS_REGION: ${{ secrets.AWS_DOCS_REGION }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DOCS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DOCS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Fix #288 
Add Publish to SNS GH Actions Workflow to trigger an update of the site when changes are pushed in this repo (not just documentation repository repos).

Also gave access to the necessary Organization Secrets as specified in this repos' README.