### PR TITLE
change internship repo name

### DIFF
--- a/repositories.yml
+++ b/repositories.yml
@@ -31,7 +31,7 @@ private:
   - RockefellerArchiveCenter/argo-docs
   - RockefellerArchiveCenter/digital-transfer-guide
   - RockefellerArchiveCenter/Archival-Education-Strategy-Document
-  - RockefellerArchiveCenter/ccny-internship-overview
+  - RockefellerArchiveCenter/cuny-internship-overview
   - RockefellerArchiveCenter/r-e-content-strategy
   - RockefellerArchiveCenter/employee-handbook
   - RockefellerArchiveCenter/reading-room-handbook
@@ -62,7 +62,7 @@ public:
   - RockefellerArchiveCenter/argo-docs
   - RockefellerArchiveCenter/digital-transfer-guide
   - RockefellerArchiveCenter/Archival-Education-Strategy-Document
-  - RockefellerArchiveCenter/ccny-internship-overview
+  - RockefellerArchiveCenter/cuny-internship-overview
   - RockefellerArchiveCenter/r-e-content-strategy
   - RockefellerArchiveCenter/reading-room-handbook
   - RockefellerArchiveCenter/employee-handbook


### PR DESCRIPTION
Changes name of the internship overview repo from ccny-internship-repo to cuny-internship-repo